### PR TITLE
🚑️: forgot to change a name to username since new name of row

### DIFF
--- a/client/src/components/leaderboard/leaderboardList/LeaderboardList.component.tsx
+++ b/client/src/components/leaderboard/leaderboardList/LeaderboardList.component.tsx
@@ -53,7 +53,7 @@ function LeaderboardList({
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({ name: input.value }),
+          body: JSON.stringify({ username: input.value }),
         },
       );
     } else


### PR DESCRIPTION
Oubli d'une variable toujours nommé name au lieu de username (depuis l'uniformisation "name" || "pseudo" => "username")