### PR TITLE
🩹: option aucun filtre fonctionnel

### DIFF
--- a/client/src/components/gallery/Gallery.tsx
+++ b/client/src/components/gallery/Gallery.tsx
@@ -22,7 +22,7 @@ function Gallery() {
   }
 
   const filteredArray =
-    selectedValue !== "Votre ville"
+    selectedValue !== "Ville"
       ? card.filter((el) => el.city.includes(selectedValue))
       : card;
 


### PR DESCRIPTION
Quand on filtrait avec une ville la galerie, puis qu'on voulait remettre "aucun filtre" ça ne fonctionnait pas