### PR TITLE
🩹: La gallerie est maintenant initialisé avec des oeuvres

### DIFF
--- a/client/src/components/gallery/Gallery.tsx
+++ b/client/src/components/gallery/Gallery.tsx
@@ -5,7 +5,7 @@ import type { CardI } from "./GalleryType";
 function Gallery() {
   const [cities, setCities] = useState<{ city: string }[]>([]);
   const [card, setCard] = useState<CardI[]>([]);
-  const [selectedValue, setSelectedValue] = useState("Votre ville");
+  const [selectedValue, setSelectedValue] = useState("Ville");
 
   useEffect(() => {
     fetch(`${import.meta.env.VITE_API_URL}/art/getCities`)


### PR DESCRIPTION
Quand on arrivait sur /gallerie, il n'y avait aucune oeuvre à cause d'une mauvaise initialisation 