### PR TITLE
Bugfix/fetchwithauth function content type

### DIFF
--- a/client/src/components/map/Print.tsx
+++ b/client/src/components/map/Print.tsx
@@ -84,7 +84,7 @@ const WebcamCapture: React.FC<WebcamCaptureProps> = ({
     const formData = new FormData();
     formData.append("image", file);
     try {
-      const response = await fetch(
+      const response = await fetchWithAuth(
         `${import.meta.env.VITE_API_URL}/api/upload`,
         {
           method: "POST",

--- a/client/src/utils/api.tsx
+++ b/client/src/utils/api.tsx
@@ -9,7 +9,6 @@ export const fetchWithAuth = async (url: string, options: RequestInit = {}) => {
 
   // On l'ajoute avec les headers passé en paramètre
   const mergedHeaders = {
-    "Content-Type": "application/json",
     ...authHeaders,
     ...(options.headers as HeadersInit),
   };

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -55,7 +55,7 @@ router.get("/user/:id", userActions.read);
 
 /* ************************** ADMIN ACTIONS ************************** */
 router.use(
-  ["/reports", "/leaderboard", "/art", "/user", "/statistics", "/api/upload"],
+  ["/reports", "/leaderboard", "/art", "/user", "/statistics"],
   authActions.verifyAdmin,
 );
 


### PR DESCRIPTION
L'upload d'images ne fonctionnait plus car notre fonction fetchwithauth ( qui a pour but de rajouter le token depuis le localstorage dans la requete ) mettait notre requete en content-type json, ce qui n'est pas bon pour une image